### PR TITLE
chore: test minimum dependencies in python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,9 @@ dependencies = [
     # Until this issue is closed
     # https://github.com/googleapis/google-cloud-python/issues/10566
     "google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
-    "proto-plus >= 1.15.0",
-    "googleapis-common-protos >= 1.56.0",
+    "proto-plus >= 1.15.0, <2.0.0dev",
+    "protobuf >= 3.19.0, <4.0.0dev",
+    "googleapis-common-protos >= 1.56.1, <2.0.0dev",
     "grpc-google-iam-v1 >= 0.12.4, <1.0.0dev",
 ]
 

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -6,5 +6,6 @@
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.31.5
 proto-plus==1.15.0
-googleapis-common-protos==1.56.0
+googleapis-common-protos==1.56.1
 grpc-google-iam-v1==0.12.4
+protobuf==3.19.0

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -6,5 +6,6 @@
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.31.5
 proto-plus==1.15.0
-googleapis-common-protos==1.56.0
+googleapis-common-protos==1.56.1
 grpc-google-iam-v1==0.12.4
+protobuf==3.19.0

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -1,0 +1,10 @@
+# This constraints file is used to check that lower bounds
+# are correct in setup.py
+# List all library dependencies and extras in this file.
+# Pin the version to the lower bound.
+# e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0dev",
+# Then this file should have google-cloud-foo==1.14.0
+google-api-core==1.31.5
+proto-plus==1.15.0
+googleapis-common-protos==1.56.0
+grpc-google-iam-v1==0.12.4


### PR DESCRIPTION
Test the minimum supported dependencies in python 3.7 unit tests to prepare for dropping python 3.6

fix(deps): require googleapis-common-protos>=1.56.1, <2.0.0dev
fix(deps): require protobuf <4.0.0dev
fix(deps): require proto-plus <2.0.0dev

Towards b/234444818